### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -15,7 +15,7 @@ class action_plugin_likeit extends DokuWiki_Action_Plugin {
 	/**
 	 * Register the eventhandlers
 	 */
-	function register(&$controller) {
+	function register(Doku_Event_Handler $controller) {
 		$controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE',  $this, '_ajax_call');
 	}
 	

--- a/syntax.php
+++ b/syntax.php
@@ -66,7 +66,7 @@ class syntax_plugin_likeit extends DokuWiki_Syntax_Plugin {
     /*
      * Handle the matches
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
     	global $ID;
     	
     	$opts = array(
@@ -81,7 +81,7 @@ class syntax_plugin_likeit extends DokuWiki_Syntax_Plugin {
     /*
      * Create output
      */
-    function render($mode, &$renderer, $opts)
+    function render($mode, Doku_Renderer $renderer, $opts)
 	{
 		if($mode == 'metadata') return false;
 		


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
